### PR TITLE
Added property DisableScrollView

### DIFF
--- a/RGPopup.Maui/Pages/PopupPage.cs
+++ b/RGPopup.Maui/Pages/PopupPage.cs
@@ -147,7 +147,15 @@ namespace RGPopup.Maui.Pages
             get => (View)GetValue(ContentProperty);
             set => SetValue(ContentProperty, value);
         }
-        
+
+        public static readonly BindableProperty DisableScrollViewProperty = BindableProperty.Create(nameof(DisableScrollView), typeof(bool), typeof(PopupPage), null);
+
+        public bool DisableScrollView
+        {
+            get => (bool)GetValue(DisableScrollViewProperty);
+            set => SetValue(DisableScrollViewProperty, value);
+        }
+
         public View CoreContent { get; private set; }
         
         public View WrappedContent { get; private set; }
@@ -160,7 +168,7 @@ namespace RGPopup.Maui.Pages
             {
                 coreContent = new ContentView() { Content = coreContent, InputTransparent = false };
             }
-            var wrappedContent = _isIOS ? new ScrollView(){ Content = coreContent, InputTransparent = false } : coreContent;
+            var wrappedContent = _isIOS && !popupPage.DisableScrollView ? new ScrollView(){ Content = coreContent, InputTransparent = false } : coreContent;
             contentPage.Content = wrappedContent;
             popupPage.CoreContent = coreContent;
             popupPage.WrappedContent = wrappedContent;


### PR DESCRIPTION
Hello,
i added the property DisableScrollView for disabling the automatic creation of the scrollview (in iOS) as a wrapper of the popuppage.

I know the scrollview is useful for automatic scroll content in case of large content in the poput, but in some case it can be useful to use the simple contentview, for example when I have a popup with inside a round border view, then a grid with a label on the top and a listview. With the scrollview, the listview are full expanded and all the border and the popup scroll on the bottom, but i want only the listview to scroll, so i put the DisableScrollView to True and put the grid with rowdefinition to "Auto,*" so the label stay on top and the listview have all the remaining height and scroll correctly.

See this code as just an example.
Hope it can be helpful.

```
<?xml version="1.0" encoding="utf-8" ?>
<PopupPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
             x:Class="_4Grapes.Popup.ListaSelezioneSingola"           
             CloseWhenBackgroundIsClicked="True"  
             DisableScrollView="True"
                  >


    <Grid HorizontalOptions="FillAndExpand" VerticalOptions="Center" Margin="40,60,40,60" RowDefinitions="Auto,*">

        <ContentView x:Name="ViewTop"  Grid.Row="0">
            <Image 
                        Source="close_yellow.png"
                        WidthRequest="20"
                        HeightRequest="20"
                        HorizontalOptions="End"
                        Margin="0,0,0,6"
                        />
        </ContentView>

        <Border  Grid.Row="1"
            VerticalOptions="FillAndExpand"
            StrokeThickness="2"
            StrokeShape="RoundRectangle 20"
            Stroke="{StaticResource Yellow}"
            BackgroundColor="{StaticResource Gray}"
               >

            <Grid HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" RowDefinitions="Auto,*">

                <Label x:Name="LblTitolo" Grid.Row="0"                    
                   FontSize="16"
                    TextColor="{StaticResource White}"
                   HorizontalTextAlignment="Center"
                   Margin="10,0,10,0"
                   />             

                <ListView x:Name="Lista" Grid.Row="1">
                    <ListView.ItemTemplate>
                        <DataTemplate>
                            <ViewCell>

                                <ContentView BackgroundColor="{Binding BackgroundColor}" VerticalOptions="FillAndExpand">

                                    <Label
                                            FontSize="16"
                                            TextColor="{Binding TextColor}"
                                            HorizontalTextAlignment="Center"
                                            VerticalOptions="Center"
                                            Text="{Binding Text}"                                            
                                        />

                                </ContentView>

                            </ViewCell>
                        </DataTemplate>
                    </ListView.ItemTemplate>
                </ListView>             

            </Grid>
        </Border>      

    </Grid>
   
</PopupPage>
```