### PR TITLE
add net 8 to framework

### DIFF
--- a/RGPopup.Maui/RGPopup.Maui.csproj
+++ b/RGPopup.Maui/RGPopup.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst;net8.0-android;net8.0-ios;net8.0-maccatalyst;</TargetFrameworks>
+        <TargetFrameworks>net8.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net8.0-android;net8.0-ios;net8.0-maccatalyst;</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
         <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->


### PR DESCRIPTION
With the new project structure, there seems to be a need to add `Net8` into the target framework to add the package. Right now, it targets specific platforms, which are separate projects in the new structure 