### PR TITLE
Fixed bug "PlatformView cannot be null here" reported by @dzebas

### DIFF
--- a/RGPopup.Maui/Platforms/iOS/Platform/PopupWindow.cs
+++ b/RGPopup.Maui/Platforms/iOS/Platform/PopupWindow.cs
@@ -1,4 +1,4 @@
-﻿using CoreGraphics;
+using CoreGraphics;
 using Foundation;
 using RGPopup.Maui.IOS.Renderers;
 using RGPopup.Maui.Pages;
@@ -38,7 +38,8 @@ namespace RGPopup.Maui.IOS.Platform
             if (formsElement.InputTransparent)
                 return null!;
 
-            UIView? nativeView = null;
+
+           UIView? nativeView = null;
             try
             {
                 nativeView = pageHandler?.PlatformView;
@@ -52,11 +53,13 @@ namespace RGPopup.Maui.IOS.Platform
                 return hitTestResult;
 
 
+            var scrollView = formsElement.WrappedContent?.Handler?.PlatformView as UIView;
+            var contentView = formsElement.CoreContent?.Handler?.PlatformView as UIView;
             var safePadding = formsElement.SafePadding;
             if ((formsElement.BackgroundClickedCommand != null || formsElement.BackgroundInputTransparent || formsElement.CloseWhenBackgroundIsClicked)
-                && Math.Max(SafeAreaInsets.Left, safePadding.Left) < point.X && point.X < (Bounds.Width - Math.Max(SafeAreaInsets.Right, safePadding.Right))
-                && Math.Max(SafeAreaInsets.Top, safePadding.Top) < point.Y && point.Y < (Bounds.Height - Math.Max(SafeAreaInsets.Bottom, safePadding.Bottom))
-                && (hitTestResult.Equals(nativeView) || hitTestResult.Equals(nativeView?.Subviews?.FirstOrDefault())))
+                && Math.Max(SafeAreaInsets.Left, safePadding.Left) < point.X && point.X < (Bounds.Width-Math.Max(SafeAreaInsets.Right, safePadding.Right))
+                && Math.Max(SafeAreaInsets.Top, safePadding.Top) < point.Y && point.Y < (Bounds.Height-Math.Max(SafeAreaInsets.Bottom, safePadding.Bottom))
+                && (hitTestResult.Equals(nativeView) || hitTestResult.Equals(contentView) || hitTestResult.Equals(scrollView) || hitTestResult.Equals(scrollView?.Subviews?.FirstOrDefault())))
             {
                 _ = formsElement.SendBackgroundClick();
                 if (formsElement.BackgroundInputTransparent)

--- a/RGPopup.Maui/Platforms/iOS/Platform/PopupWindow.cs
+++ b/RGPopup.Maui/Platforms/iOS/Platform/PopupWindow.cs
@@ -38,14 +38,25 @@ namespace RGPopup.Maui.IOS.Platform
             if (formsElement.InputTransparent)
                 return null!;
 
-            var nativeView = pageHandler?.PlatformView;
-            var scrollView = formsElement.WrappedContent?.Handler?.PlatformView as UIView;
-            var contentView = formsElement.CoreContent?.Handler?.PlatformView as UIView;
+            UIView? nativeView = null;
+            try
+            {
+                nativeView = pageHandler?.PlatformView;
+            }
+            catch (InvalidOperationException)
+            {
+                return hitTestResult;
+            }
+
+            if (nativeView == null)
+                return hitTestResult;
+
+
             var safePadding = formsElement.SafePadding;
             if ((formsElement.BackgroundClickedCommand != null || formsElement.BackgroundInputTransparent || formsElement.CloseWhenBackgroundIsClicked)
-                && Math.Max(SafeAreaInsets.Left, safePadding.Left) < point.X && point.X < (Bounds.Width-Math.Max(SafeAreaInsets.Right, safePadding.Right))
-                && Math.Max(SafeAreaInsets.Top, safePadding.Top) < point.Y && point.Y < (Bounds.Height-Math.Max(SafeAreaInsets.Bottom, safePadding.Bottom))
-                && (hitTestResult.Equals(nativeView) || hitTestResult.Equals(contentView) || hitTestResult.Equals(scrollView) || hitTestResult.Equals(scrollView?.Subviews?.FirstOrDefault())))
+                && Math.Max(SafeAreaInsets.Left, safePadding.Left) < point.X && point.X < (Bounds.Width - Math.Max(SafeAreaInsets.Right, safePadding.Right))
+                && Math.Max(SafeAreaInsets.Top, safePadding.Top) < point.Y && point.Y < (Bounds.Height - Math.Max(SafeAreaInsets.Bottom, safePadding.Bottom))
+                && (hitTestResult.Equals(nativeView) || hitTestResult.Equals(nativeView?.Subviews?.FirstOrDefault())))
             {
                 _ = formsElement.SendBackgroundClick();
                 if (formsElement.BackgroundInputTransparent)


### PR DESCRIPTION
PlatformView throws an internal exception so I didn't find the cause of it being null, in this case I opted for an exception handler. If you can find a more appropriate handler, please consider changing it.

https://github.com/microspaze/RGPopup.Maui/issues/27